### PR TITLE
Potential fix for code scanning alert no. 90: Information exposure through an exception

### DIFF
--- a/containers/content-ranker/service_logic.py
+++ b/containers/content-ranker/service_logic.py
@@ -278,5 +278,5 @@ class ContentRankerService:
                 "service": "content-ranker",
                 "status": "error",
                 "timestamp": datetime.utcnow().isoformat(),
-                "error": str(e),
+                "error": "Failed to get ranking status",
             }


### PR DESCRIPTION
Potential fix for [https://github.com/Hardcoreprawn/ai-content-farm/security/code-scanning/90](https://github.com/Hardcoreprawn/ai-content-farm/security/code-scanning/90)

To fix the vulnerability, we need to ensure that no sensitive exception data—including raw exception messages, stack traces, file names, etc.—is returned in responses accessible to external parties. Specifically:

- In `ContentRankerService.get_ranking_status`, if an exception occurs, we should still return a safe, generic error message to the user instead of exposing `str(e)`.
- Internally, the detailed exception can still be logged to help with debugging, but the API response should never directly contain any raw exception data.
- In the `/status` endpoint handler in `main.py`, no changes are needed since it properly raises a generic HTTP exception if a top-level error occurs. We only need to sanitize the service logic path to ensure `status_data` is always safe.
- Edit the method `get_ranking_status` in `service_logic.py`: Replace the `"error": str(e)` field in the error response with a generic message (e.g., `"error": "Failed to get ranking status"`).

No additional imports or new packages are required. This is a minimal change and preserves the error-handling and logging behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
