### PR TITLE
Fix site-generator to accept article_content field from processor

### DIFF
--- a/containers/site-generator/content_processing_functions.py
+++ b/containers/site-generator/content_processing_functions.py
@@ -105,10 +105,19 @@ async def generate_markdown_batch(
                         validation_rule="type_check",
                     )
 
-                required_fields = ["title", "content"]
+                # Check for required fields - support both 'content' and 'article_content'
+                required_fields = ["title"]
                 missing_fields = [
                     field for field in required_fields if not article_data.get(field)
                 ]
+
+                # Validate content field (accept either 'content' or 'article_content')
+                has_content = article_data.get("content") or article_data.get(
+                    "article_content"
+                )
+                if not has_content:
+                    missing_fields.append("content or article_content")
+
                 if missing_fields:
                     raise ValidationError(
                         f"Missing required fields: {missing_fields}",

--- a/containers/site-generator/content_utility_functions.py
+++ b/containers/site-generator/content_utility_functions.py
@@ -366,7 +366,8 @@ def create_markdown_content(article_data: Dict[str, Any]) -> str:
     """
     # Extract article information
     title = article_data.get("title", "Untitled")
-    content = article_data.get("content", "")
+    # Support both 'content' and 'article_content' field names for compatibility
+    content = article_data.get("content") or article_data.get("article_content", "")
     topic_id = article_data.get("topic_id", "")
     source = article_data.get("source", "unknown")
 


### PR DESCRIPTION
## Problem
The processor container saves enriched content as `article_content` field, but the site-generator was only validating and extracting the `content` field. This caused all 10 articles to fail validation with `ValidationError`.

## Root Cause
Field name mismatch between containers:
- **Processor output**: `article_content`
- **Site-generator expected**: `content`

## Solution
Updated site-generator to accept both field names for backward compatibility:
1. `content_utility_functions.py`: Extract either `content` or `article_content`
2. `content_processing_functions.py`: Validate that either field exists

## Testing
✅ All 82 site-generator tests pass
✅ Verified with actual processed content from blob storage

## Container Logs Evidence
- **Collector**: Successfully writes to blob and sends queue messages ✅
- **Processor**: Receives messages, processes 10 topics, saves with `article_content` field ✅  
- **Site-generator**: Was failing validation - now fixed ✅

## Deployment
This will be deployed via CI/CD pipeline to production once merged to main.