### PR TITLE
fix: resolve circular dependency in dependabot-automerge workflow

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -89,12 +89,15 @@ jobs:
           check_interval=30
 
           while [ $wait_time -lt $max_wait ]; do
-            # Get all check runs for this PR (state field only)
+            # Get all check runs for this PR, excluding this workflow itself
             checks=$(gh pr checks ${{ github.event.pull_request.number }} --json state,name)
 
-            # Count pending/in-progress checks
-            pending=$(echo "$checks" | jq '[.[] | select(.state == "PENDING" or .state == "IN_PROGRESS" or .state == "QUEUED")] | length')
-            failed=$(echo "$checks" | jq '[.[] | select(.state == "FAILURE" or .state == "ERROR")] | length')
+            # Exclude this workflow's own checks to avoid circular dependency
+            filtered_checks=$(echo "$checks" | jq '[.[] | select(.name != "dependabot-checks")]')
+
+            # Count pending/in-progress checks (excluding ourselves)
+            pending=$(echo "$filtered_checks" | jq '[.[] | select(.state == "PENDING" or .state == "IN_PROGRESS" or .state == "QUEUED")] | length')
+            failed=$(echo "$filtered_checks" | jq '[.[] | select(.state == "FAILURE" or .state == "ERROR")] | length')
 
             if [ "$failed" -gt 0 ]; then
               echo "[FAIL] One or more CI checks failed"


### PR DESCRIPTION
## Problem

The Dependabot auto-merge workflow was timing out after 30 minutes on every PR, preventing any Dependabot PRs from auto-merging.

### Root Cause
The `dependabot-checks` job was waiting for **all** PR checks to complete, including itself. This created a circular dependency:

1. `dependabot-checks` runs and starts waiting for checks
2. It calls `gh pr checks` which returns ALL checks including `dependabot-checks`
3. Since `dependabot-checks` is still running (waiting), it sees itself as "1 check still running"
4. It waits 30 minutes for itself to finish → timeout → failure

### Evidence
From the logs of PR #570:
```
⏳ 1 checks still running... (waited 0s)
⏳ 1 checks still running... (waited 30s)
...
⏳ 1 checks still running... (waited 1770s)
⏰ Timeout waiting for CI checks
```

## Solution

Modified the "Wait for CI checks" step to **exclude itself** from the checks it's monitoring:

```bash
# NEW: Filter out this workflow's own checks
filtered_checks=$(echo "$checks" | jq '[.[] | select(.name != "dependabot-checks")]')

# Count only OTHER checks (not ourselves)
pending=$(echo "$filtered_checks" | jq '[...] | length')
```

## Testing

This PR will test the fix:
- ✅ The workflow should now complete quickly (not wait 30 minutes)
- ✅ Other checks (Security, Quality, etc.) will still be properly monitored
- ✅ Auto-merge should trigger after all real checks pass

## Impact

Fixes all 5 blocked Dependabot PRs:
- #570 - hypothesis update
- #569 - fastapi update  
- #566 - urllib3 update
- #565 - certifi update
- #555 - hypothesis update

Once this merges, those PRs should auto-merge within minutes instead of timing out.